### PR TITLE
[CBP-42405] chore: Update latest image version in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
   steps:
     - id: invoke-newrelic-job
       name: invoke-newrelic-job
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/newrelic-actions:main-a75e573065744eea07a4ec365d23f66e24532661
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/newrelic-actions:main-6f0eac4b0abe49445121cac27d6f8affd2c85980
       shell: sh
       env:
         RUN_ID: ${{ cloudbees.run_id }}


### PR DESCRIPTION
Update docker image tag to latest version from `action_artifacts.json`.